### PR TITLE
Removing the MealPlanView

### DIFF
--- a/mealie/Views/MainTabView.swift
+++ b/mealie/Views/MainTabView.swift
@@ -34,10 +34,10 @@ struct MainTabBodyView : View {
                 .tabItem {
                     Label("Recipes", systemImage: "book")
                 }
-            MealPlanView()
-                .tabItem {
-                    Label("Calendar", systemImage: "calendar")
-                }
+//            MealPlanView()
+//                .tabItem {
+//                    Label("Calendar", systemImage: "calendar")
+//                }
             ProfileView(recipesViewModel: recipesViewModel, mealieAPIService: self.mealieAPIService)
                 .tabItem {
                     Label("Profile", systemImage: "person")


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed the Calendar (Meal Plan) tab from the main tab bar to streamline navigation. Home, Recipes, and Profile tabs remain unchanged.
  * The Calendar/Meal Plan view is no longer accessible from the tab bar; no impact to launch behavior or existing tab interactions.
  * No changes to settings, notifications, or other visible UI elements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->