### PR TITLE
Changed the name of the app

### DIFF
--- a/mealIO.xcodeproj/project.pbxproj
+++ b/mealIO.xcodeproj/project.pbxproj
@@ -444,7 +444,7 @@
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = mealie/Info.plist;
-				INFOPLIST_KEY_CFBundleDisplayName = MealIO;
+				INFOPLIST_KEY_CFBundleDisplayName = Gourmet;
 				INFOPLIST_KEY_ITSAppUsesNonExemptEncryption = NO;
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
@@ -478,7 +478,7 @@
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = mealie/Info.plist;
-				INFOPLIST_KEY_CFBundleDisplayName = MealIO;
+				INFOPLIST_KEY_CFBundleDisplayName = Gourmet;
 				INFOPLIST_KEY_ITSAppUsesNonExemptEncryption = NO;
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;

--- a/mealie/Views/LoginView.swift
+++ b/mealie/Views/LoginView.swift
@@ -22,7 +22,7 @@ struct LoginBodyView: View {
     var body: some View {
         VStack(spacing: 32) {
             Spacer()
-            Text("Mealie for iOS")
+            Text("Gourmet for Mealie")
                 .font(.title)
                 .bold()
             VStack(spacing: 16) {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the app’s display name from “MealIO” to “Gourmet” across all build configurations.
  * Refreshed the login screen header to “Gourmet for Mealie” for consistent branding.

* **Chores**
  * Aligned project configuration with the new app name to ensure the updated branding appears correctly in Debug and Release builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->